### PR TITLE
Made logo bigger and menu align fix for mobile view

### DIFF
--- a/less/bootstrap/navbar.less
+++ b/less/bootstrap/navbar.less
@@ -195,6 +195,7 @@
   float: right;
   margin-right: @navbar-padding-horizontal;
   padding: 9px 10px;
+  margin-top: 12px !important;
   .navbar-vertical-align(34px);
   background-color: transparent;
   background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214

--- a/less/style.less
+++ b/less/style.less
@@ -70,3 +70,8 @@ a, a:hover, a:visited, a:active, a:focus {
 .bootbox {
 	z-index: 100001;
 }
+
+.logo {
+	width: 220px; 
+	margin-top: 0px;
+}

--- a/templates/partials/menu.tpl
+++ b/templates/partials/menu.tpl
@@ -8,7 +8,7 @@
 
 				<!-- IF brand:logo -->
 				<a href="<!-- IF brand:logo:url -->{brand:logo:url}<!-- ELSE -->{relative_path}/<!-- ENDIF brand:logo:url -->">
-					<img alt="{brand:logo:alt}" class="{brand:logo:display} forum-logo" src="{brand:logo}" />
+					<img class="logo" alt="{brand:logo:alt}" class="{brand:logo:display} forum-logo" src="{brand:logo}" />
 				</a>
 				<!-- ENDIF brand:logo -->
 


### PR DESCRIPTION
Changed `less/bootstrap/navbar.less` for menu align for mobile view.
Changed `less/style.less` and `templates/partials/menu.tpl` for logo size.